### PR TITLE
Prepare codebase for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: crystal
+script:
+  - shards install
+  - crystal spec
+  - shards build --no-codegen

--- a/shard.yml
+++ b/shard.yml
@@ -14,4 +14,4 @@ license: MIT
 
 targets:
   tournamentbot:
-    main: src/tournamentbot.cr
+    main: src/entrypoint.cr

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,0 +1,2 @@
+require "spec"
+require "../src/tournamentbot"

--- a/spec/tournamentbot_spec.cr
+++ b/spec/tournamentbot_spec.cr
@@ -1,0 +1,7 @@
+require "./spec_helper"
+
+describe TournamentBot::Bot do
+  it "initializes" do
+    TournamentBot::Bot.new("token", 123)
+  end
+end

--- a/src/config.cr
+++ b/src/config.cr
@@ -1,0 +1,19 @@
+module TournamentBot
+  class Config
+    include YAML::Serializable
+
+    getter token : String
+    getter owner_id : UInt64
+    getter client_id : UInt64
+
+    def initialize(@token : String, @owner_id : UInt64, @client_id : UInt64)
+    end
+
+    def self.load(filename)
+      document = File.read(filename)
+      from_yaml(document)
+    rescue ex : YAML::ParseException
+      abort("Failed to parse #{filename}:\n  #{ex.message}")
+    end
+  end
+end

--- a/src/entrypoint.cr
+++ b/src/entrypoint.cr
@@ -1,0 +1,3 @@
+require "./tournamentbot"
+
+TournamentBot.run

--- a/src/entrypoint.cr
+++ b/src/entrypoint.cr
@@ -1,3 +1,4 @@
 require "./tournamentbot"
 
-TournamentBot.run
+config = TournamentBot::Config.load("./src/config.yml")
+TournamentBot.run(config)

--- a/src/plugins/info.cr
+++ b/src/plugins/info.cr
@@ -4,7 +4,7 @@ class TournamentBot::Info
 
   @[Discord::Handler(event: :message_create, middleware: Command.new("!info"))]
   def info(payload, _ctx)
-    bot = client.cache.try &.resolve_user(CLIENT_ID)
+    bot = client.cache.try &.resolve_user(TournamentBot.config.client_id)
     return unless bot
 
     embed = Discord::Embed.new

--- a/src/plugins/tournament_creator.cr
+++ b/src/plugins/tournament_creator.cr
@@ -376,12 +376,13 @@ module TournamentBot::TournamentCreator
     end
 
     private def load_tournaments
-      dir = Dir.open("./tournament-files")
+      Dir.open("./tournament-files") do |dir|
 
-      dir.each do |name|
-        next if name =~ /^\.\.?$/
-        guild_id = name.split(".").first
-        @tournaments[guild_id.to_u64] = Tournament.from_yaml(File.read("./tournament-files/#{name}"))
+        dir.each do |name|
+          next if name =~ /^\.\.?$/
+          guild_id = name.split(".").first
+          @tournaments[guild_id.to_u64] = Tournament.from_yaml(File.read("./tournament-files/#{name}"))
+        end
       end
     end
 

--- a/src/tournamentbot.cr
+++ b/src/tournamentbot.cr
@@ -4,6 +4,7 @@ require "discordcr-plugin"
 require "discordcr-middleware"
 require "discordcr-middleware/middleware/prefix"
 
+require "./config"
 require "./plugins/*"
 require "./middlewares/*"
 require "./tournaments/*"
@@ -11,11 +12,12 @@ require "./tournaments/*"
 module TournamentBot
   class Bot
     getter client : Discord::Client
+    getter client_id : UInt64
     getter cache : Discord::Cache
     delegate run, stop, to: client
 
-    def initialize
-      @client = Discord::Client.new(token: "Bot #{AUTH["token"].as_s}", client_id: CLIENT_ID)
+    def initialize(token : String, @client_id : UInt64)
+      @client = Discord::Client.new(token: "Bot #{token}", client_id: @client_id)
       @cache = Discord::Cache.new(@client)
       @client.cache = @cache
       register_plugins
@@ -26,12 +28,11 @@ module TournamentBot
     end
   end
 
-  AUTH      = YAML.parse(File.read("./src/config.yml"))
-  OWNER_ID  = AUTH["owner"].as_i.to_u64
-  CLIENT_ID = AUTH["client_id"].as_i.to_u64
+  class_getter! config : Config
 
-  def self.run
-    bot = Bot.new
+  def self.run(config : Config)
+    @@config = config
+    bot = Bot.new(config.token, config.client_id)
     bot.run
   end
 end

--- a/src/tournamentbot.cr
+++ b/src/tournamentbot.cr
@@ -4,6 +4,8 @@ require "discordcr-plugin"
 require "discordcr-middleware"
 require "discordcr-middleware/middleware/prefix"
 
+Dir.mkdir_p("./tournament-files")
+
 require "./config"
 require "./plugins/*"
 require "./middlewares/*"
@@ -36,5 +38,3 @@ module TournamentBot
     bot.run
   end
 end
-
-Dir.mkdir_p("./tournaments")

--- a/src/tournamentbot.cr
+++ b/src/tournamentbot.cr
@@ -36,5 +36,4 @@ module TournamentBot
   end
 end
 
-Dir.mkdir("./tournaments") unless Dir.exists?("./tournaments")
-TournamentBot.run
+Dir.mkdir_p("./tournaments")


### PR DESCRIPTION
This PR accomplishes a few things:

- Specs on master cannot be run, because requiring the main file *also* executes the bot (`TournamentBot.run`). Here I take several steps to isolate runtime behavior to `entrypoint.cr`, and to decrease the global state footprint to a single `Config` class, available anywhere as `TournamentBot.config`. This allows us to safely require the whole codebase (*except* `entrypoint.cr`) and freely instantiate "fake" instances of `Config`, `Bot`, etc. as we please.

- `Config.load` is added to abstract `YAML.parse(File.read(..))`. Helpful later as this can be super easily extended for other config formats by reading extname. This aborts if parsing fails, and hides the unhelpful backtrace.

- This includes two small fixes in 5f3bd7d to close a dangling `Dir` handler, and to correct the directory name in the main file. We also now use `Dir.mkdir_p` to remove the need for `unless`.

- Travis CI is enabled, with a simple "thumbs up" spec that `Bot` can be instantiated. It's a little silly, and it can be removed later, but it doesn't hurt - and just proves my work here was sound without veering off course of the subject of this PR. It tests three things:

1. Dependencies install correctly
2. Specs pass
3. The runtime compiles (`--no-codegen` disables generation of the binary, waste of time for CI)

- `Bot#client_id` (note: *not `Client`*) is also added, but not used yet. *Eventually* support for sharding can be very simply added into `run` - another reason for this refactor. Then, there can be `TournamentBot.get_shard(guild_id)` which eliminates needs for checks like `client.cache.try ...`, and others.