### PR TITLE
Add TournamentBot.bot, sharding support

### DIFF
--- a/spec/tournamentbot_spec.cr
+++ b/spec/tournamentbot_spec.cr
@@ -2,6 +2,6 @@ require "./spec_helper"
 
 describe TournamentBot::Bot do
   it "initializes" do
-    TournamentBot::Bot.new("token", 123)
+    TournamentBot::Bot.new("token", 123, 0, 1)
   end
 end

--- a/src/config.cr
+++ b/src/config.cr
@@ -5,6 +5,7 @@ module TournamentBot
     getter token : String
     getter owner_id : UInt64
     getter client_id : UInt64
+    getter shard_count : Int32 = 1
 
     def initialize(@token : String, @owner_id : UInt64, @client_id : UInt64)
     end

--- a/src/entrypoint.cr
+++ b/src/entrypoint.cr
@@ -2,3 +2,4 @@ require "./tournamentbot"
 
 config = TournamentBot::Config.load("./src/config.yml")
 TournamentBot.run(config)
+sleep

--- a/src/tournamentbot.cr
+++ b/src/tournamentbot.cr
@@ -19,9 +19,10 @@ module TournamentBot
     getter cache     : Discord::Cache
     delegate run, stop, to: client
 
-    def initialize(token : String, @client_id : UInt64)
-      @client       = Discord::Client.new(token: "Bot #{token}", client_id: @client_id)
-      @cache        = Discord::Cache.new(@client)
+    def initialize(token : String, @client_id : UInt64, shard_id, num_shards)
+      @client = Discord::Client.new(token: "Bot #{token}", client_id: @client_id,
+                                    shard: {shard_id: shard_id, num_shards: num_shards})
+      @cache = Discord::Cache.new(@client)
       @client.cache = @cache
       register_plugins
     end
@@ -34,9 +35,30 @@ module TournamentBot
   FORMATTER = Time::Format.new("%A, %-d.%-m.2018 at %I:%M%p UTC+0", Time::Location.fixed("UTC", 0))
   class_getter! config : Config
 
+  @@shards = [] of Bot
+
+  def self.bot(guild_id : UInt64 | Snowflake | Nil = nil)
+    if guild_id
+      shard_id = (guild_id >> 22) % config.shard_count
+      @@shards[shard_id]
+    else
+      @@shards[0]
+    end
+  end
+
   def self.run(config : Config)
     @@config = config
-    bot = Bot.new(config.token, config.client_id)
-    bot.run
+
+    config.shard_count.times do |id|
+      bot = Bot.new(config.token, config.client_id, id, config.shard_count)
+      @@shards << bot
+      spawn { bot.run }
+    end
+  end
+
+  def self.stop
+    @@shards.each do |bot|
+      bot.stop
+    end
   end
 end


### PR DESCRIPTION
This allows global accessing to all running shards within the current process via TournamentBot.bot(guild_id). guild_id is optional, if not supplied defaults to the first shard.

```cr
bot = TournamentBot.bot
bot.client # => Discord::Client
bot.cache  # => Discord::Cache
```